### PR TITLE
Token Service and AuthHttpClientHandler

### DIFF
--- a/HobbyMatchApp/Auth/AuthHttpClientHandler.cs
+++ b/HobbyMatchApp/Auth/AuthHttpClientHandler.cs
@@ -1,0 +1,46 @@
+﻿using System.Net.Http.Headers;
+using System.Net;
+using Microsoft.Extensions.Options;
+using HobbyMatch.App.Auth.TokenService;
+
+namespace HobbyMatch.App.Auth
+{
+	/// <summary>
+	/// This class is responsible for adding the Authorization header and baseUrl from appSettings to the request
+	/// Use it whenever you need to send an authenticated request to the API.
+	/// </summary>
+	public class AuthHttpClientHandler : DelegatingHandler
+	{
+		private readonly ITokenService _tokenService;
+		private readonly string _baseUrl;
+		public AuthHttpClientHandler(ITokenService tokenService, IOptions<ApiSettings> apiSettings)
+		{
+			_tokenService = tokenService;
+			_baseUrl = apiSettings.Value.BaseUrl;
+		}
+
+		protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+		{
+			if (!request.RequestUri.IsAbsoluteUri)
+			{
+				var combinedUri = new Uri(new Uri(_baseUrl), request.RequestUri);
+				request.RequestUri = combinedUri;
+			}
+			var token = await _tokenService.GetAccessTokenAsync();
+			if (token != null)
+			{
+				request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+				var response = await base.SendAsync(request, cancellationToken);
+				return response;
+			}
+			else
+				return new HttpResponseMessage(HttpStatusCode.Unauthorized);
+		}
+	}
+}
+
+public class ApiSettings
+{
+	public string BaseUrl { get; set; } = String.Empty;
+}

--- a/HobbyMatchApp/Auth/TokenService/ITokenService.cs
+++ b/HobbyMatchApp/Auth/TokenService/ITokenService.cs
@@ -1,0 +1,15 @@
+﻿using System.Security.Claims;
+
+namespace HobbyMatch.App.Auth.TokenService
+{
+	/// <summary>
+	/// This interface is responsible for managing the access token
+	/// </summary>
+	public interface ITokenService
+	{
+		Task SetAccessTokenAsync(string token);
+		Task<string?> GetAccessTokenAsync();
+		Task ClearAccessTokenAsync();
+		Task<IEnumerable<Claim>> GetClaimsFromTokenAsync();
+	}
+}

--- a/HobbyMatchApp/Auth/TokenService/TokenService.cs
+++ b/HobbyMatchApp/Auth/TokenService/TokenService.cs
@@ -1,0 +1,63 @@
+﻿
+using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+
+namespace HobbyMatch.App.Auth.TokenService
+{
+	/// <summary>
+	/// This class is responsible for managing the access token. 
+	/// Use it to set (on Login or Refresh), get (on Api Requests), and clear (on Logout) the access token.
+	/// Use it to get claims from the access token.
+	/// </summary>
+	public class TokenService : ITokenService
+	{
+		private readonly ProtectedLocalStorage _localStorage;
+		private string? _accessToken;
+		private string _accessTokenName = "accessToken";
+
+		public TokenService(ProtectedLocalStorage localStorage)
+		{
+			_localStorage = localStorage;
+		}
+
+		public async Task SetAccessTokenAsync(string token)
+		{
+			_accessToken = token;
+			await _localStorage.SetAsync(_accessTokenName, token);
+		}
+
+		public async Task<string?> GetAccessTokenAsync()
+		{
+			if (!string.IsNullOrEmpty(_accessToken))
+				return _accessToken;
+
+			var result = await _localStorage.GetAsync<string>("accessToken");
+			if (result.Success)
+			{
+				_accessToken = result.Value;
+				return _accessToken;
+			}
+
+			return null;
+		}
+
+		public async Task ClearAccessTokenAsync()
+		{
+			_accessToken = null;
+			await _localStorage.DeleteAsync(_accessTokenName);
+		}
+
+		public async Task<IEnumerable<Claim>> GetClaimsFromTokenAsync()
+		{
+			var token = await GetAccessTokenAsync();
+			if (string.IsNullOrEmpty(token))
+				return Enumerable.Empty<Claim>();
+
+			var handler = new JwtSecurityTokenHandler();
+			var jwtToken = handler.ReadJwtToken(token);
+
+			return jwtToken.Claims;
+		}
+	}
+}

--- a/HobbyMatchApp/HobbyMatch.App.csproj
+++ b/HobbyMatchApp/HobbyMatch.App.csproj
@@ -1,9 +1,13 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.7.0" />
+  </ItemGroup>
 
 </Project>

--- a/HobbyMatchApp/Program.cs
+++ b/HobbyMatchApp/Program.cs
@@ -1,10 +1,23 @@
+using HobbyMatch.App.Auth;
+using HobbyMatch.App.Auth.TokenService;
 using HobbyMatch.App.Components;
+using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
+using Microsoft.Extensions.Configuration;
 
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
 builder.Services.AddRazorComponents()
-    .AddInteractiveServerComponents();
+.AddInteractiveServerComponents();
+builder.Services.Configure<ApiSettings>(builder.Configuration.GetSection("ApiSettings"));
+
+builder.Services.AddTransient<AuthHttpClientHandler>();
+
+builder.Services.AddScoped<ProtectedLocalStorage>();
+builder.Services.AddScoped<ITokenService, TokenService>();
+
+builder.Services.AddHttpClient("AuthenticatedClient")
+	.AddHttpMessageHandler<AuthHttpClientHandler>();
 
 var app = builder.Build();
 

--- a/HobbyMatchApp/appsettings.json
+++ b/HobbyMatchApp/appsettings.json
@@ -5,5 +5,8 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "ApiSettings": {
+    "BaseUrl": "https://localhost:7298/api"
+  }
 }


### PR DESCRIPTION
Created:
- TokenService (to be used by eg. authenticationState provider )
- AuthHttpCliendHandler, which adds baseAddress to requests and access token. Use it whenever your reuqest needs to be authenticated (which is every requests besides sign up and log in)

resolves #22 